### PR TITLE
ci: fix auto-merge-deps reusable workflow reference

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -2,11 +2,12 @@ name: Auto-merge dependency PRs
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+
+permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml@main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
The caller pointed at `netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml`, which does not exist. The real reusable workflow lives at `netresearch/.github/.github/workflows/auto-merge-deps.yml`. Every `pull_request` event failed to resolve it.

## Changes

- `uses:` → correct org-level reusable workflow
- `on: pull_request` → `on: pull_request_target` (Dependabot/Renovate PRs get write-scoped creds)

## Context

Batch fix across ~30 repos that inherited this from the `skill-repo-skill` template. Upstream template fix: netresearch/skill-repo-skill#66