### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context7",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Fetch up-to-date library documentation via Context7 REST API",
   "repository": "https://github.com/netresearch/context7-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when looking up library documentation, API references, framewo
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires curl or fetch, jq."
 metadata:
-  version: "1.4.1"
+  version: "1.5.0"
   repository: "https://github.com/netresearch/context7-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
## Release v1.5.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/context7/SKILL.md` frontmatter `metadata.version` from `1.4.1` to `1.5.0`.

### Highlights since v1.4.1

- Ship the skill as an npm package via `@netresearch/agent-skill-coordinator`, with a follow-up fix to drop the top-level `scripts/` directory from the tarball (#24).
- Release workflow grants SLSA provenance permissions and drops the deprecated `workflow_dispatch.bump` input (#22, #23).
- CI plumbing: forward the `bump` input from `workflow_dispatch` to the reusable release workflow (#21).

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
