### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context7",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Fetch up-to-date library documentation via Context7 REST API",
   "repository": "https://github.com/netresearch/context7-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when looking up library documentation, API references, framewo
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires curl or fetch, jq."
 metadata:
-  version: "1.5.0"
+  version: "1.6.0"
   repository: "https://github.com/netresearch/context7-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Release **v1.6.0** (minor bump, conventional commits since v1.5.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.6.0.

Changes since v1.5.0:
- feat: add .pre-commit-config.yaml mirroring CI checks
- 
- Wires netresearch/skill-repo-skill@v1.22.0 as a pre-commit hook
- provider so validate-skill, check-version-parity, and the standard
- linter set (markdownlint-cli2, yamllint, actionlint, ruff, shellcheck)
- run locally before commit instead of only in CI.
- - package.json scripts.prepare: invokes pre-commit install --install-hooks
-   if pre-commit is on PATH; silent no-op otherwise. Auto-activates hooks
-   on `npm install`.
- 
- Part of the fleet rollout following netresearch/agent-harness-skill#27
- (CI/Hook Parity Principle) and skill-repo-skill v1.22.0 (hook exposure).
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- feat: add .pre-commit-config.yaml mirroring CI checks (#26)
- 
- ## Summary
- 
- Wires
- [`netresearch/skill-repo-skill@v1.22.0`](https://github.com/netresearch/skill-repo-skill/releases/tag/v1.22.0)

After merge: a signed tag `v1.6.0` on `main` triggers the release workflow.