### PR TITLE
docs(skill): scope description to MCP-fallback, drop duplicate mode section

### DIFF
--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context7
-description: "Use when looking up library documentation, API references, framework patterns, or code examples for ANY library (React, Next.js, Vue, Django, Laravel, etc.). Fetches current docs via Context7 REST API. Triggers on: how to use library, API docs, framework pattern, import usage, library example."
+description: "Use when looking up library documentation, API references, framework patterns, or code examples for ANY library (React, Next.js, Vue, Django, Laravel, etc.) and the Context7 MCP server is unavailable or not configured. Fetches the same current docs directly via the Context7 REST API as a fallback, no MCP tool schemas required. Triggers on: how to use library, API docs, framework pattern, import usage, library example."
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires curl or fetch, jq."
 metadata:
@@ -57,12 +57,6 @@ Always extract a specific topic from the user's question. For "How does React Su
 | `library-id` | Yes | From search results, format `/vendor/library` |
 | `topic` | No | Focus area extracted from user query (e.g., `hooks`, `routing`, `validation`) |
 | `mode` | No | `code` (default) for API references; `info` for conceptual guides |
-
-## Mode Selection
-
-Use `code` mode (default) when the user asks for API references, code examples, or implementation patterns.
-
-Use `info` mode when the user asks for conceptual explanations, architecture guides, or migration tutorials.
 
 ## Examples
 

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context7
-description: "Use when looking up library documentation, API references, framework patterns, or code examples for ANY library (React, Next.js, Vue, Django, Laravel, etc.) and the Context7 MCP server is unavailable or not configured. Fetches the same current docs directly via the Context7 REST API as a fallback, no MCP tool schemas required. Triggers on: how to use library, API docs, framework pattern, import usage, library example."
+description: "Use when looking up library documentation, API references, framework patterns, or code examples for ANY library (React, Next.js, Vue, Django, Laravel, etc.) and the Context7 MCP server is unavailable or not configured. Fetches the same current docs directly via the Context7 REST API as a fallback. Triggers on: how to use library, API docs, framework pattern, import usage, library example."
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires curl or fetch, jq."
 metadata:


### PR DESCRIPTION
Part of netresearch/skill-repo-skill#157. Ticks the `context7` checkbox: "context7 — description gains MCP-fallback scope clause".

## Rubric

Per [skills/skill-repo/references/skill-quality.md § Content value rubric](https://github.com/netresearch/skill-repo-skill/blob/main/skills/skill-repo/references/skill-quality.md#content-value-rubric): cut only content a one-line prompt regenerates or that restates content already stated elsewhere in the same file; keep org specifics, executable scripts, and anything an agent needs to disambiguate trigger scope.

## Changed

- **Description (frontmatter):** added the MCP-fallback scope clause the audit asked for — the skill now states it applies "when the Context7 MCP server is unavailable or not configured", fetching the same docs via direct REST call as a fallback. This disambiguates trigger scope against the actual `context7` MCP plugin (`mcp__plugin_context7_context7__query-docs` / `resolve-library-id`), which should be preferred when present. 294 → 421 chars (still under the 500-char WARN threshold; well under the 1,536 hard cap).
- **Body:** dropped the `## Mode Selection` section — its two sentences fully restated the `mode` row already in the `## Parameters` table (same `code`/`info` distinction, same wording). Pure duplication, not new information — fits the "restated content" bloat class.

## Kept (and why)

- `## When to Use` / `## When NOT to Use` — negative-scope bullets (general programming concepts, code review, refactoring, debugging business logic) are exercised directly by `evals/evals.json` (`negative-general-programming`, `negative-code-review`, `negative-refactoring`, `negative-debugging`). Cutting them risks the eval's trigger-scoping behavior, not just word count.
- `## Core Workflow` step 2's guidance to prefer official sources over community forks, and the topic-extraction example — these are tool-specific usage guidance (Context7 library-ID resolution flow), not generic doc-reading tutorial content.
- `## Examples` (4 worked examples with real library IDs) — kept as-is; this is a "small task" per the tracking issue and the examples demonstrate the two-step search→docs flow plus both `mode` values, not restated public best practice.
- README.md / AGENTS.md / docs/ARCHITECTURE.md — out of scope for this PR; the audit item names only the SKILL.md description.

## Verification

Re-verified against the current tree (repo was 5 commits behind when I started; pulled first). `README.md`/`AGENTS.md`/`docs/ARCHITECTURE.md` already frame this skill as a lightweight REST alternative to the Context7 MCP with no persistent context overhead — the new description clause is consistent with that existing framing, just now stated as an explicit trigger-scope condition rather than only a cost-comparison rationale.

```
$ wc -w skills/context7/SKILL.md   # before (origin/main)
421 skills/context7/SKILL.md
$ wc -w skills/context7/SKILL.md   # after
409 skills/context7/SKILL.md
```

```
$ bash validate-skill.sh .
OK: SKILL.md is 409 words (under 500 limit)
...
Errors:   0
Warnings: 6   (pre-existing README section-heading warnings, unrelated to this change)
Skill repository is valid!
```

```
$ grep -rln "Fetches current docs via Context7 REST API\|Mode Selection" --include="*.md" --include="*.json" .
(no output — no dangling references to the removed heading or old description string)
```

`scripts/audit-skills.sh .` reports `GENERIC SHARE: 0%` and `DESCRIPTION: [WARN]` — the WARN figure it prints (843 chars) is inflated by a doubling bug in that script's own `get_description` awk (`exit` inside a mid-loop rule re-triggers the `END` block, printing the value twice) that reproduces identically on `origin/main`'s pre-edit description; the true single-instance length is 421 chars, confirmed by direct extraction. Not fixed here (out of scope, lives in `skill-repo-skill`).

Pre-commit (`validate-skill`, `check-version-parity`) passed clean on the changed file. `markdownlint-cli2` reports one pre-existing `MD034` bare-URL finding on line 91 (`> **Contributing:** ...`) that predates this change (present unmodified on `origin/main`, and that commit's own CI `Lint` run is green — a version/glob difference between the pinned local pre-commit hook and the CI action, not something this diff touches).

Not merging — leaving for review per task instructions.
