### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context7",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Fetch up-to-date library documentation via Context7 REST API",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "context7",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Fetch up-to-date library documentation via Context7 REST API",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when looking up library documentation, API references, framewo
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires curl or fetch, jq."
 metadata:
-  version: "1.6.1"
+  version: "1.7.0"
   repository: "https://github.com/netresearch/context7-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Release v1.7.0.

Version bump only.

Bumped: root `plugin.json`, `.claude-plugin/plugin.json`, every `skills/*/SKILL.md` frontmatter version. Parity verified with `check-version-parity.sh v1.7.0`.

Tag `v1.7.0` follows once this merges.