### PR TITLE
chore(release): v1.7.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context7",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Fetch up-to-date library documentation via Context7 REST API",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "context7",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Fetch up-to-date library documentation via Context7 REST API",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when looking up library documentation, API references, framewo
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires curl or fetch, jq."
 metadata:
-  version: "1.7.1"
+  version: "1.7.2"
   repository: "https://github.com/netresearch/context7-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Version bump to 1.7.2 (patch). Changes since v1.7.1:

- chore(renovate): enable the pre-commit manager, pin validator at v1.36.0
- docs: complete the marketplace setup steps
- docs: correct the skills-directory install instructions
- chore(dependabot): remove the Dependabot configuration

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5